### PR TITLE
Allow SOCS Cookie

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -23,6 +23,12 @@
 	"captchaCookieDescription": {
 		"message": "Unter bestimmten Umständen muss ein Captcha gelöst werden, um weiter bei Google suchen zu können. Dieser Cookie speichert das erfolgreiche Lösen eines Captchas. Da der Cookie eine kurze Lebensdauer hat und nicht oft vorkommt, wird empfohlen ihn zu erlauben."
 	},
+	"cookieChoicesCookieName": {
+		"message": "Cookie Auswahl Cookie"
+	},
+	"cookieChoicesCookieDescription": {
+		"message": "Speichern Sie den Zustand eines Benutzers bezüglich seiner Cookie-Auswahl."
+	},
 	"optionsAllow": {
 		"message": "Erlauben"
 	},

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -23,6 +23,12 @@
 	"captchaCookieDescription": {
 		"message": "Under certain circumstances a CAPTCHA has to be solved in order to continue searching on Google. This Cookie saves if a CAPTCHA has successfully been solved. Since the cookie is short lived and not too common it is recommended to allow it."
 	},
+	"cookieChoicesCookieName": {
+		"message": "Cookie Choices Cookie"
+	},
+	"cookieChoicesCookieDescription": {
+		"message": "Store a user’s state regarding their cookies choices."
+	},
 	"optionsAllow": {
 		"message": "Allow"
 	},

--- a/src/settings.js
+++ b/src/settings.js
@@ -28,6 +28,14 @@ class Settings {
 					value: 1,
 				}
 			],
+			[
+				'allowCookieChoices',
+				{
+					locale: 'cookieChoicesCookie',
+					name: 'SOCS',
+					value: 1,
+				}
+			]
 		]);
 	}
 


### PR DESCRIPTION
This cookie is "used to store a user’s state regarding their cookies choices." and will fix the issue of the cookie choices dialogue popping up continuously. Not sure about privacy concerns regarding this. Used Google translate for the German locale so probably needs to be changed somewhat. 

See: [https://policies.google.com/technologies/cookies?hl=en-US](https://policies.google.com/technologies/cookies?hl=en-US)

